### PR TITLE
Add Unpaywall fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # pddoi
 
-https://colab.research.google.com/drive/1xxKl_oIMaclLqyIsudqeGS3kC2IrWC5R?usp=sharing
+This Streamlit app downloads academic papers using their DOIs. It first tries
+several Sci-Hub mirrors and, if none succeed, falls back to the Unpaywall API to
+fetch any available open access versions. Upload a text file containing DOIs
+separated by commas and the app will attempt to download them and bundle the
+results into a ZIP file.


### PR DESCRIPTION
## Summary
- add fallback to `download_open_access` when all Sci-Hub mirrors fail
- document the new download behavior in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68415a44247c832aa7f0a560b0d41414