### PR TITLE
Update Sci-Hub mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,25 @@
 # pddoi
 
 This Streamlit app downloads academic papers using their DOIs. It first tries
-several Sci-Hub mirrors and, if none succeed, falls back to the Unpaywall API to
+up to three Sci-Hub mirrors and, if none succeed, falls back to the Unpaywall API to
 fetch any available open access versions. Upload a text file containing DOIs
 separated by commas and the app will attempt to download them and bundle the
 results into a ZIP file.
 
+## Default Sci-Hub Mirrors
 
-Runr the following colab link:
+The app ships with three pre-configured mirrors which have been found to be more
+reliable. You can replace them or add your own within the app, but only the
+first three will be used during a download session. If a mirror responds with
+`403 Forbidden`, the request is automatically retried through the `r.jina.ai`
+proxy to bypass simple blocking.
+
+```
+https://sci-hub.box/
+https://sci-hub.se/
+https://sci-hub.wf/
+```
+
+
+Run using the following Colab link:
 https://colab.research.google.com/drive/1xxKl_oIMaclLqyIsudqeGS3kC2IrWC5R?usp=sharing


### PR DESCRIPTION
## Summary
- add `https://sci-hub.box/` as the primary mirror
- keep default list to three mirrors
- default download mirror uses `sci-hub.box`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68415e8ed858832a91a69bc81a950a86